### PR TITLE
add generic unix build support

### DIFF
--- a/_bin/build_prod_unix.sh
+++ b/_bin/build_prod_unix.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+targets="manager broker agent web_backend importer"
+for target in $targets; do 
+  go build -tags prod -ldflags="-s" -ldflags="-w" -o $target.bin ../$target
+done


### PR DESCRIPTION
This 5 addidional LOC would allow to build this project on any golang supported unix with a generic (non-bash) posix shell (FreeBSD,OpenBSD,NetBSD,Darwin,AIX,...).

Details:
-ldflags "-s -w" works only on bash/dash, -ldflags=''-w' -ldflags="-s" works on every posix shell env